### PR TITLE
Add Strategy to cli args, allowing users to get mobile or desktop results.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ var debug = require('debug')('pagespeed-cli')
 var port = args.p || args.port
 var strategy = args.s || args.strategy
 
+if (!strategy) {
+  console.log('Missing "strategy" parameter, using "mobile"')
+  strategy = 'mobile'
+}
+
 if (!port) {
   console.log('Missing "port" parameter')
   process.exit(1)
@@ -53,6 +58,6 @@ function getPagespeed (url) {
       // We also have to wrap the resolving into a timeout, since `psi` resolves
       // before everything finished writing into the console
       setTimeout(resolve, 500)
-    }).catch((e) => setTimeout(() => reject(e), 500));
+    }).catch(reject)
   })
 }

--- a/index.js
+++ b/index.js
@@ -48,10 +48,11 @@ function getPagespeed (url) {
     threshold: 1,
     strategy: strategy.toString()
   }
+  return new Promise(function (resolve, reject) {
     psi.output(url, options).then(function () {
       // We also have to wrap the resolving into a timeout, since `psi` resolves
       // before everything finished writing into the console
       setTimeout(resolve, 500)
-    })
+    }).catch((e) => setTimeout(() => reject(e), 500));
   })
 }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var portUsed = require('tcp-port-used')
 var debug = require('debug')('pagespeed-cli')
 
 var port = args.p || args.port
+var strategy = args.s || args.strategy
 
 if (!port) {
   console.log('Missing "port" parameter')
@@ -15,6 +16,7 @@ if (!port) {
 debug('Checking if local port ' + port + ' is in use')
 portUsed.check(port, '127.0.0.1').then(function (inUse) {
   if (!inUse) {
+    console.log('Strategy: ' + strategy)
     console.log('Local port ' + port + ' is not in use')
     process.exit(1)
   }
@@ -42,8 +44,10 @@ function tunnelPSI (port) {
 function getPagespeed (url) {
   // We **have** to set a threshold of 1 here, else the output may throw an error
   // if the default threshold is not met, resulting into the `psi` promise never getting resolved
-  var options = {threshold: 1}
-  return new Promise(function (resolve) {
+  var options = {
+    threshold: 1,
+    strategy: strategy.toString()
+  }
     psi.output(url, options).then(function () {
       // We also have to wrap the resolving into a timeout, since `psi` resolves
       // before everything finished writing into the console


### PR DESCRIPTION
Hey! Love the project, it's super helpful!

I wanted a way to get desktop results too, so here's the feature. :)

I also added a catch in the final promise, as my version of node threw a warning that unhandled promise rejections would be deprecated soon, so now we catch any errors thrown by psi.output :)